### PR TITLE
LINUXCN-18 Update to Debian 11 LXD 5

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 This repo is used to build the Triton Datacenter Linux platform image. This is
 not a standalone product and is intended to be used with Triton Datacenter.
 
-**THIS IS A TECHNOLOGY PREVIEW.** Not everythign works as expected yet. But you
+**THIS IS A TECHNOLOGY PREVIEW.** Not everything works as expected yet. But you
 (yes, you!) can help shape the direction of the product by getting involved.
 
 Detailed documentation can be found in the [docs](docs) directory. Some of this

--- a/docs/6-quick-start.md
+++ b/docs/6-quick-start.md
@@ -46,7 +46,7 @@ up to date as possible with Linux CN images. Things can move pretty fast.
 
 3. Install the image
 
-        sdcadm platform install ./platform-20210731T223008Z.tgz
+        sdcadm platform install ./platform-20230609T214426Z.tgz
 
 ## Compute Node Setup
 

--- a/docs/6-quick-start.md
+++ b/docs/6-quick-start.md
@@ -42,7 +42,7 @@ up to date as possible with Linux CN images. Things can move pretty fast.
 
         mkdir /var/tmp/linuxcn
         cd /var/tmp/linuxcn
-        curl -OC - https://us-central.manta.mnx.io/Joyent_Dev/public/TritonDCLinux/20210731T223008Z/platform-20210731T223008Z.tgz
+        curl -OC - https://us-central.manta.mnx.io/Joyent_Dev/public/TritonDCLinux/20230609T214426Z/platform-20230609T214426Z.tgz
 
 3. Install the image
 

--- a/docs/6-quick-start.md
+++ b/docs/6-quick-start.md
@@ -6,7 +6,7 @@
 
 <!--
     Copyright 2021 Joyent, Inc.
-    Copyright 2022 MNX Cloud, Inc.
+    Copyright 2023 MNX Cloud, Inc.
 -->
 
 # Triton Datacenter Linux CN Quick Start Guide
@@ -27,7 +27,7 @@ There will most likely be breaking changes with little to no warning.
    [Triton Maintenance and Upgrades][triton-upgrade] documentation.
 2. Update `imgapi` to the latest `dev` image.
 
-        sdcadm update -C dev imgapi --latest
+        sdcadm update -C dev imgapi
 
 ## Obtaining Linux Platform Images
 
@@ -63,7 +63,7 @@ Make sure you are sure!!
 3. Issue the `sdc-factoryreset` command
 4. After the server reboots, power it off. This can be done with IPMI if you
    have that available.
-5. Delete the server from CNAPI. First make note of the CN UUID, then delte it
+5. Delete the server from CNAPI. First make note of the CN UUID, then delete it
 
         sdc-server delete <CN UUID>
 
@@ -80,9 +80,13 @@ Make sure you are sure!!
 
 1. Boot the CN. It will boot to the default platform image, which will most
    likely be SmartOS.
-2. Assign a Linux platform, and reboot it
+2. Assign a Linux platform, set kernel args, and reboot:
 
         sdcadm platform assign <platform> <CN UUID>
+
+        sdc-cnapi /boot/<CN UUID> -X PUT -d \
+            '{"kernel_args": {"systemd.unified_cgroup_hierarchy": "0"}}'
+
         sdc-oneachnode -n <CN UUID> 'exit 113'
 
 3. The CN will now boot to the designated platform image.

--- a/tools/debian-live
+++ b/tools/debian-live
@@ -260,7 +260,7 @@ function install_live {
 	chroot "$root" tee /etc/apt/preferences.d/90_zfs >/dev/null <<-EOF
 	# https://github.com/zfsonlinux/zfs/wiki/Debian#installation
 	Package: libnvpair1linux libuutil1linux libzfs2linux libzpool2linux spl-dkms zfs-dkms zfs-test zfsutils-linux zfsutils-linux-dev zfs-zed
-	Pin: release n=buster-backports
+	Pin: release n=bullseye-backports
 	Pin-Priority: 990
 	EOF
 
@@ -373,7 +373,7 @@ function install_usr_triton {
 
 	    # Symlink lib/node to ensure global node_modules is on the require path.
 	    # XXX - why is this node_modules not already on the nodejs require path?
-	    # This is a long explanation. Can do some reading on node docs for details:
+	    # This is a long explanation. Can do some reading on node docs for details:
 	    # https://nodejs.org/api/modules.html#modules_loading_from_the_global_folders
 	    # Note we should be doing this instead where a global module is required:
 	    # export NODE_PATH=/usr/lib/node_modules
@@ -447,7 +447,7 @@ function install_usr_triton_cn_agent {
 	    set -xeuo pipefail
 	    export LC_ALL=C
 
-	    git -C /usr/triton/defaults/agents clone -b linuxcn https://github.com/TritonDataCenter/sdc-cn-agent cn-agent
+	    git -C /usr/triton/defaults/agents clone -b LINUXCN-19 https://github.com/TritonDataCenter/sdc-cn-agent cn-agent
 	    cd /usr/triton/defaults/agents/cn-agent
 	    rm -f package-lock.json
 	    npm install --production --ignore-scripts
@@ -600,7 +600,7 @@ function install_lxd {
 	curl -L https://golang.org/dl/go${golang_ver}.linux-amd64.tar.gz |
 	    chroot "$root" tar -C /usr/local --no-same-owner -xzf -
 	LXD_RELEASE=lxd-$lxd_ver
-	curl -L https://github.com/lxc/lxd/releases/download/$LXD_RELEASE/$LXD_RELEASE.tar.gz |
+	curl -L https://github.com/canonical/lxd/releases/download/$LXD_RELEASE/$LXD_RELEASE.tar.gz |
 	    chroot "$root" tar -C /tmp --no-same-owner -xzf -
 	# shellcheck disable=2016
 	chroot "$root" env lxd_ver=$lxd_ver bash -c '
@@ -1092,15 +1092,6 @@ scratch=$top/scratch
 mkdir -p "$scratch"
 repo=$(git rev-parse --show-toplevel)
 
-motd_alt=$'
-   __        .                   .
- _|  |_      | .-. .  . .-. :--. |-
-|_    _|     ;|   ||  |(.-\' |  | |
-  |__|   `--\'  `-\' `;-| `-\' \'  \' `-\'
-                   /  ;  Platform ('"$name"' '"$release"$')
-                   `-\'   '"$docurl"'
-'
-
 motd=$'
             *--+--*--*
            /| /| /| /|
@@ -1114,8 +1105,6 @@ motd=$'
          *--*--+--*         build: '"$release"'
 
 '
-
-: "$motd_alt"
 
 commit=$(cd "$(dirname "$0")" && git rev-parse HEAD)
 product="

--- a/tools/debian-live
+++ b/tools/debian-live
@@ -42,7 +42,7 @@ docurl=https://github.com/joyent/linux-live
 golang_ver=1.15.6
 rust_version=1.52.0
 
-kernel_version=5.10.0-8
+kernel_version=5.10.0-18
 lxd_ver=4.0.6
 zfs_ver=2.0.4
 

--- a/tools/debian-live
+++ b/tools/debian-live
@@ -35,14 +35,14 @@ if [[ -f ~/.cargo/env ]]; then
 	source ~/.cargo/env
 fi
 
-debver=buster
-name="Debian 10"
-docurl=https://github.com/TritonDataCenter/linux-live
+debver=bullseye
+name="Debian 11"
+docurl=https://github.com/joyent/linux-live
 
 golang_ver=1.15.6
 rust_version=1.52.0
 
-kernel_version=5.10.0-0.bpo.15
+kernel_version=5.10.0-8
 lxd_ver=4.0.6
 zfs_ver=2.0.4
 
@@ -99,7 +99,7 @@ packages+=(nodejs)
 # required by lxd:
 packages+=(iptables apparmor apparmor-profiles apparmor-utils liblxc1 lxc lxcfs
     acl autoconf dnsmasq-base git libtool rsync pkg-config make tar tcl libuv1
-    squashfs-tools xz-utils ebtables lvm2 thin-provisioning-tools btrfs-tools
+    squashfs-tools xz-utils ebtables lvm2 thin-provisioning-tools btrfs-progs
 )
 
 # These packages are here to aid in building the image - they are installed
@@ -237,19 +237,19 @@ function install_live {
 	deb http://deb.debian.org/debian/ $debver main
 	deb-src http://deb.debian.org/debian/ $debver main
 
-	deb http://security.debian.org/debian-security $debver/updates main
-	deb-src http://security.debian.org/debian-security $debver/updates main
+	deb http://security.debian.org/debian-security ${debver}-security main
+	deb-src http://security.debian.org/debian-security ${debver}-security main
 
 	deb http://deb.debian.org/debian/ $debver-updates main
 	deb-src http://deb.debian.org/debian/ $debver-updates main
 	EOF
 
-	chroot "$root" tee /etc/apt/sources.list.d/$debver-backports.list \
-	    >/dev/null <<-EOF
-	# https://github.com/zfsonlinux/zfs/wiki/Debian#installation
-	deb http://deb.debian.org/debian $debver-backports main contrib
-	deb-src http://deb.debian.org/debian $debver-backports main contrib
-	EOF
+	#chroot "$root" tee /etc/apt/sources.list.d/$debver-backports.list \
+	#    >/dev/null <<-EOF
+	## https://github.com/zfsonlinux/zfs/wiki/Debian#installation
+	#deb http://deb.debian.org/debian $debver-backports main contrib
+	#deb-src http://deb.debian.org/debian $debver-backports main contrib
+	#EOF
 
 	chroot "$root" tee /etc/apt/preferences.d/90_zfs >/dev/null <<-EOF
 	# https://github.com/zfsonlinux/zfs/wiki/Debian#installation
@@ -271,8 +271,8 @@ function install_kernel_packages {
 	    "linux-headers-${kernel_version}-amd64"
 
 	# This removes the old kernel
-	chroot "$root" env DEBIAN_FRONTEND=noninteractive apt-get remove \
-	    "linux-image-4*" "linux-headers-4*" "linux-kbuild-4*"
+	#chroot "$root" env DEBIAN_FRONTEND=noninteractive apt-get remove \
+	    #"linux-image-4*" "linux-headers-4*" "linux-kbuild-4*"
 }
 
 # Install system packages.
@@ -345,7 +345,7 @@ function remove_temporary_packages {
 		export DEBIAN_FRONTEND=noninteractive
 		export LC_ALL=C
 
-		apt remove -y $pkgs "kernel-headers-*"
+		apt remove -y $pkgs "linux-headers-*"
 		apt-get autoremove --purge -y
 
 		rm -f /tmp/zfs-modules-*.deb

--- a/tools/debian-live
+++ b/tools/debian-live
@@ -91,6 +91,7 @@ packages+=(
     sysstat
     tcpdump
     vim
+    sharutils
 )
 
 # Agents build relies on uuid.

--- a/tools/debian-live
+++ b/tools/debian-live
@@ -8,7 +8,7 @@
 
 #
 # Copyright 2021 Joyent, Inc.
-# Copyright 2022 MNX Cloud, Inc.
+# Copyright 2023 MNX Cloud, Inc.
 #
 
 #
@@ -37,13 +37,16 @@ fi
 
 debver=bullseye
 name="Debian 11"
-docurl=https://github.com/joyent/linux-live
+docurl=https://github.com/TritonDataCenter/linux-live
 
-golang_ver=1.15.6
+# LXD >= 5 requies go >= 1.18
+golang_ver=1.18.10
 rust_version=1.52.0
 
-kernel_version=5.10.0-18
-lxd_ver=4.0.6
+kernel_version=5.10.0-21
+
+# $MAJOR.0.$PATCH are LTS releases for LXD
+lxd_ver=5.0.1
 zfs_ver=2.0.4
 
 # From https://willhaley.com/blog/custom-debian-live-environment/
@@ -100,6 +103,7 @@ packages+=(nodejs)
 packages+=(iptables apparmor apparmor-profiles apparmor-utils liblxc1 lxc lxcfs
     acl autoconf dnsmasq-base git libtool rsync pkg-config make tar tcl libuv1
     squashfs-tools xz-utils ebtables lvm2 thin-provisioning-tools btrfs-progs
+    attr
 )
 
 # These packages are here to aid in building the image - they are installed
@@ -111,7 +115,8 @@ temp_build_packages=(gawk alien libblkid-dev uuid-dev libudev-dev libssl-dev
 )
 
 # packages required to build lxd
-temp_build_packages+=(libacl1-dev libcap-dev lxc-dev libuv1-dev patchelf)
+temp_build_packages+=(libacl1-dev libcap-dev lxc-dev libuv1-dev patchelf
+	liblz4-dev shellcheck)
 
 # These are for the lxd test suite:
 temp_build_packages+=(libapparmor-dev libseccomp-dev libcap-dev gettext
@@ -469,7 +474,6 @@ function install_usr_triton_imgadm {
 	'
 }
 
-
 # Install config-agent and the dependencies (nice to have a build of this).
 function install_usr_triton_config_agent {
 	# git -C $scratch clone -b linuxcn https://github.com/TritonDataCenter/sdc-config-agent
@@ -489,7 +493,6 @@ function install_usr_triton_config_agent {
 	    uuid -v4 > image_uuid
 	'
 }
-
 
 # Install net-agent and the dependencies (nice to have a build of this).
 function install_usr_triton_net_agent {
@@ -511,7 +514,6 @@ function install_usr_triton_net_agent {
 	'
 }
 
-
 # Install vm-agent and the dependencies (nice to have a build of this).
 function install_usr_triton_vm_agent {
 	chroot "$root" bash -c '
@@ -526,7 +528,6 @@ function install_usr_triton_vm_agent {
         uuid -v4 > image_uuid
 	'
 }
-
 
 # Install metadata agent and the dependencies (nice to have a build of this).
 function install_usr_triton_metadata {
@@ -543,7 +544,6 @@ function install_usr_triton_metadata {
 	'
 }
 
-
 # Install vminfod and the dependencies (nice to have a build of this).
 function install_usr_triton_vminfod {
 	chroot "$root" bash -c '
@@ -558,7 +558,6 @@ function install_usr_triton_vminfod {
 		uuid -v4 > image_uuid
 	'
 }
-
 
 function install_proto {
 	(cd "$repo/src" && make install)
@@ -592,7 +591,6 @@ function install_proto {
 		ln -s /usr/triton/bin/sysinfo /usr/bin/sysinfo
 	    fi
 	'
-
 }
 
 # Build and install LXC/LXD. Like ZFS, eventually this should be done
@@ -619,16 +617,26 @@ function install_lxd {
 	    export GOBIN=$GOPATH/bin
 
 	    make deps
-	    export CGO_CFLAGS="-I${GOPATH}/deps/sqlite/ -I${GOPATH}/deps/libco/ -I${GOPATH}/deps/raft/include/ -I${GOPATH}/deps/dqlite/include/"
-	    export CGO_LDFLAGS="-L${GOPATH}/deps/sqlite/.libs/ -L${GOPATH}/deps/libco/ -L${GOPATH}/deps/raft/.libs -L${GOPATH}/deps/dqlite/.libs/"
-	    export LD_LIBRARY_PATH="${GOPATH}/deps/sqlite/.libs/:${GOPATH}/deps/libco/:${GOPATH}/deps/raft/.libs/:${GOPATH}/deps/dqlite/.libs/"
-	    export CGO_LDFLAGS_ALLOW="-Wl,-wrap,pthread_create"
+
+	    export CGO_CFLAGS="-I${LXD_RELEASE}/vendor/raft/include/ -I${LXD_RELEASE}/vendor/dqlite/include/"
+	    export CGO_LDFLAGS="-L${LXD_RELEASE}/vendor/raft/.libs/ -L${LXD_RELEASE}/vendor/dqlite/.libs/"
+	    export LD_LIBRARY_PATH="${LXD_RELEASE}/vendor/raft/.libs/:${LXD_RELEASE}/vendor/dqlite/.libs/"
+	    export CGO_LDFLAGS_ALLOW="(-Wl,-wrap,pthread_create)|(-Wl,-z,now)"
 
 	    make
+
 	    mv $(pwd)/_dist /usr/local/lxd
 
+	    mkdir -p /usr/local/lxd/vendor/raft/.libs
+	    mv vendor/raft/.libs/*.so* /usr/local/lxd/vendor/raft/.libs
+
+	    mkdir -p /usr/local/lxd/vendor/dqlite/.libs
+	    mv vendor/dqlite/.libs/*.so* /usr/local/lxd/vendor/dqlite/.libs
+
 	    # Add dynamic libraries to the lxd binary rpath.
-	    patchelf --set-rpath "\$ORIGIN/../deps/raft/.libs:\$ORIGIN/../deps/dqlite/.libs" /usr/local/lxd/bin/lxd
+	    patchelf --set-rpath "\$ORIGIN/../vendor/raft/.libs:\$ORIGIN/../vendor/dqlite/.libs" /usr/local/lxd/bin/lxd
+	    patchelf --set-rpath "\$ORIGIN/../vendor/raft/.libs:\$ORIGIN/../vendor/dqlite/.libs" /usr/local/lxd/bin/lxc-to-lxd
+	    patchelf --set-rpath "\$ORIGIN/../../raft/.libs" /usr/local/lxd/vendor/dqlite/.libs/libdqlite.so.0
 
 	    rm -Rf /usr/local/go
 	'
@@ -709,7 +717,7 @@ function prepare_archive_bits {
 	cp "$root/initrd.img" "$image/initrd"
 
 	cat <<EOF >"$scratch/grub.cfg"
-search --set=root --file /JOYENT_DEBIAN_LIVE
+search --set=root --file /TRITON_DEBIAN_LIVE
 
 insmod all_video
 
@@ -721,21 +729,21 @@ terminal_input --append serial
 terminal_output --append serial
 
 menuentry "Triton Debian Live $release without DHCP ttyS0" {
-    linux /vmlinuz boot=live console=tty0 console=ttyS1
+    linux /vmlinuz boot=live console=tty0 console=ttyS1 systemd.unified_cgroup_hierarchy=0
     initrd /initrd
 }
 
 menuentry "Triton Debian Live $release with default networking" {
-    linux /vmlinuz boot=live console=tty0 console=ttyS1 triton.dhcp-all-nics
+    linux /vmlinuz boot=live console=tty0 console=ttyS1 triton.dhcp-all-nics systemd.unified_cgroup_hierarchy=0
     initrd /initrd
 }
 
 menuentry "Triton Debian Live $release without DHCP" {
-    linux /vmlinuz boot=live
+    linux /vmlinuz boot=live systemd.unified_cgroup_hierarchy=0
     initrd /initrd
 }
 EOF
-	echo "$release" > "$image/JOYENT_DEBIAN_LIVE"
+	echo "$release" > "$image/TRITON_DEBIAN_LIVE"
 }
 
 function create_tgz {
@@ -800,17 +808,17 @@ function create_iso {
 	    "$scratch/bios.img"
 
 	xorriso -as mkisofs -iso-level 3 -full-iso9660-filenames \
-	    -volid "JOYENT_DEBIAN_LIVE" -eltorito-boot boot/grub/bios.img \
+	    -volid "TRITON_DEBIAN_LIVE" -eltorito-boot boot/grub/bios.img \
 	    -no-emul-boot -boot-load-size 4 -boot-info-table \
 	    --eltorito-catalog boot/grub/boot.cat --grub2-boot-info \
 	    --grub2-mbr /usr/lib/grub/i386-pc/boot_hybrid.img \
 	    -eltorito-alt-boot -e EFI/efiboot.img -no-emul-boot \
 	    -append_partition 2 0xef "$scratch/efiboot.img" \
-	    -output "$top/joyent-debian_live-$release.iso" \
+	    -output "$top/triton-debian_live-$release.iso" \
 	    -graft-points "$image" /boot/grub/bios.img="$scratch/bios.img" \
 	    /EFI/efiboot.img="$scratch/efiboot.img"
 
-	    ln -f -s "${top}/joyent-debian_live-$release.iso" "$top/../joyent-debian_live-latest.iso"
+	    ln -f -s "${top}/triton-debian_live-$release.iso" "$top/../triton-debian_live-latest.iso"
 }
 
 # Creates a USB disk that should be bootable with BIOS or UEFI. The partition
@@ -832,7 +840,7 @@ function create_usb {
 	local image_mnt=$scratch/mnt/image
 	local total_sec=$(( image_start + image_sec ))
 	local disk_mb=$(( total_sec / 2 / 1024 + 1 ))
-	local disk_file=$scratch/joyent-debian_live-$release.usb
+	local disk_file=$scratch/triton-debian_live-$release.usb
 
 	truncate -s "$disk_mb"M "$disk_file"
 
@@ -906,9 +914,9 @@ function create_usb {
 	umount "$image_mnt"
 	umount "$esp_mnt"
 
-	rm -f "$top/joyent-debian_live-$release.usb.gz"
-	pigz -c "$disk_file" > "$top/joyent-debian_live-$release.usb.gz"
-	ln -f -s "${top}/joyent-debian_live-$release.usb.gz" "$top/../joyent-debian_live-latest.usb.gz"
+	rm -f "$top/triton-debian_live-$release.usb.gz"
+	pigz -c "$disk_file" > "$top/triton-debian_live-$release.usb.gz"
+	ln -f -s "${top}/triton-debian_live-$release.usb.gz" "$top/../triton-debian_live-latest.usb.gz"
 
 }
 
@@ -1094,7 +1102,7 @@ motd_alt=$'
 
 motd=$'
             *--+--*--*
-           /| /| /| /|    J O Y E N T
+           /| /| /| /|
           / |/ |/ |/ |    #####  ####   #  #####  ###   #   # TM
          +--*--+--*--*      #    #   #  #    #   #   #  ##  #
          | /| /| /| /|      #    ####   #    #   #   #  # # #


### PR DESCRIPTION
Update to Debian 11 and LXD 5.0.1 (latest LTS) 

Tested locally also confirmed that a container created with LXD v4 will still work with LXD v5 after a PI upgrade.

Depends on TritonDataCenter/sdc-headnode/pull/78