### PR TITLE
LINUXCN-18 Update Linux CN to Debian 12 and LXD 5

### DIFF
--- a/docs/2-platform-image.md
+++ b/docs/2-platform-image.md
@@ -6,7 +6,7 @@
 
 <!--
     Copyright 2020 Joyent, Inc.
-    Copyright 2022 MNX Cloud, Inc.
+    Copyright 2023 MNX Cloud, Inc.
 -->
 
 # Platform Image
@@ -20,13 +20,14 @@ The platform image is based on Debian utilizing ZFS on Linux.
 
 ### TLDR
 
-1. Install [Debian 10 64-bit](https://www.debian.org/CD/http-ftp/) on a machine
+1. Install [Debian 12 64-bit](https://www.debian.org/CD/http-ftp/) on a machine
    (e.g. in VMware)
 2. Install [ZFS](#install-zfs)
 3. Create a zpool (warning - this will destroy the disk partition), e.g.
 
     ```bash
-    zpool create data /dev/sdb
+    sudo zpool create data /dev/sdb
+    sudo zfs create data/debian-live
     sudo touch /data/.system_pool
     ```
 
@@ -377,11 +378,12 @@ Once you have a Debian instance with ZFS, perform the following steps.
 
 #### Create a zpool
 
-For now, the image creation script assumes that there is a pool named `triton`
-where it can create images.
+For now, the image creation script assumes that there is a pool named `data`
+and a dataset named `debian-live` where it can create images.
 
 ```bash
 sudo zpool create data /dev/vdb
+sudo zfs create data/debian-live
 ```
 
 If you will be developing and testing agents on this box, you probably want to

--- a/docs/6-quick-start.md
+++ b/docs/6-quick-start.md
@@ -80,13 +80,9 @@ Make sure you are sure!!
 
 1. Boot the CN. It will boot to the default platform image, which will most
    likely be SmartOS.
-2. Assign a Linux platform, set kernel args, and reboot:
+2. Assign a Linux platform, and reboot it
 
         sdcadm platform assign <platform> <CN UUID>
-
-        sdc-cnapi /boot/<CN UUID> -X PUT -d \
-            '{"kernel_args": {"systemd.unified_cgroup_hierarchy": "0"}}'
-
         sdc-oneachnode -n <CN UUID> 'exit 113'
 
 3. The CN will now boot to the designated platform image.

--- a/docs/6-quick-start.md
+++ b/docs/6-quick-start.md
@@ -6,7 +6,7 @@
 
 <!--
     Copyright 2021 Joyent, Inc.
-    Copyright 2022 MNX Cloud, Inc.
+    Copyright 2023 MNX Cloud, Inc.
 -->
 
 # Triton Datacenter Linux CN Quick Start Guide
@@ -27,7 +27,7 @@ There will most likely be breaking changes with little to no warning.
    [Triton Maintenance and Upgrades][triton-upgrade] documentation.
 2. Update `imgapi` to the latest `dev` image.
 
-        sdcadm update -C dev imgapi --latest
+        sdcadm update -C dev imgapi
 
 ## Obtaining Linux Platform Images
 
@@ -63,7 +63,7 @@ Make sure you are sure!!
 3. Issue the `sdc-factoryreset` command
 4. After the server reboots, power it off. This can be done with IPMI if you
    have that available.
-5. Delete the server from CNAPI. First make note of the CN UUID, then delte it
+5. Delete the server from CNAPI. First make note of the CN UUID, then delete it
 
         sdc-server delete <CN UUID>
 
@@ -80,9 +80,13 @@ Make sure you are sure!!
 
 1. Boot the CN. It will boot to the default platform image, which will most
    likely be SmartOS.
-2. Assign a Linux platform, and reboot it
+2. Assign a Linux platform, set kernel args, and reboot:
 
         sdcadm platform assign <platform> <CN UUID>
+
+        sdc-cnapi /boot/<CN UUID> -X PUT -d \
+            '{"kernel_args": {"systemd.unified_cgroup_hierarchy": "0"}}'
+
         sdc-oneachnode -n <CN UUID> 'exit 113'
 
 3. The CN will now boot to the designated platform image.

--- a/proto/etc/resolv.conf
+++ b/proto/etc/resolv.conf
@@ -1,1 +1,0 @@
-/run/systemd/resolve/stub-resolv.conf

--- a/tools/debian-live
+++ b/tools/debian-live
@@ -57,7 +57,7 @@ golang_ver=1.18.10
 go_distfile="https://golang.org/dl/go${golang_ver}.linux-${arch}.tar.gz"
 
 # https://github.com/openzfs/zfs/releases
-zfs_ver=2.2.0
+zfs_ver=2.2.1
 zfs_distfile="https://github.com/openzfs/zfs/releases/download/zfs-${zfs_ver}/zfs-${zfs_ver}.tar.gz"
 
 # Last Python 2 version released (needed for node-gyp)
@@ -1067,6 +1067,16 @@ function create_usb {
 
 }
 
+function finished {
+	echo "Finished building release: $release"
+	echo "Files:"
+	for f in "$top/platform-$release.tgz" \
+	    "$top/triton-debian_live-$release.iso" \
+	    "$top/triton-debian_live-$release.usb.gz"; do
+		echo "  - $f ($(stat -c '%s' "$f" | numfmt --to=iec))"
+	done
+}
+
 function run {
 	local step=$1
 	local isFirstStep=$2
@@ -1161,6 +1171,7 @@ if [[ "$arch" == "amd64" ]]; then
 		create_tgz
 		create_iso
 		create_usb
+		finished
 	)
 fi
 

--- a/tools/debian-live
+++ b/tools/debian-live
@@ -8,7 +8,7 @@
 
 #
 # Copyright 2021 Joyent, Inc.
-# Copyright 2023 MNX Cloud, Inc.
+# Copyright 2024 MNX Cloud, Inc.
 #
 
 #
@@ -46,7 +46,7 @@ docurl=https://github.com/TritonDataCenter/linux-live
 arch=$(dpkg --print-architecture)
 machine=$(uname -m)
 
-kernel_version=6.1.0-13
+kernel_version=6.1.69-1
 
 # Currently keeping this up with the latest version in pkgsrc bootstrap kits
 # https://us-central.manta.mnx.io/pkgsrc/public/pkg-bootstraps/index.html
@@ -323,8 +323,8 @@ function install_live {
 function install_kernel_packages {
 	chroot "$root" env DEBIAN_FRONTEND=noninteractive LC_ALL=C \
 	    apt install "${apt_args[@]}" \
-	    "linux-image-${kernel_version}-${arch}" \
-	    "linux-headers-${kernel_version}-${arch}"
+	    "linux-image-${arch}=${kernel_version}" \
+	    "linux-headers-${arch}=${kernel_version}"
 }
 
 # Install system packages.
@@ -1097,6 +1097,13 @@ function create_usb {
 
 function finished {
 	echo "Finished building release: $release"
+
+	printf "Debian version: ${debver} "
+	chroot "$root" cat /etc/debian_version
+
+	printf "Kernel version: "
+	chroot "$root" uname -vr
+
 	echo "Files:"
 	for f in "$top/platform-$release.tgz" \
 	    "$top/triton-debian_live-$release.iso" \

--- a/tools/debian-live
+++ b/tools/debian-live
@@ -847,7 +847,7 @@ function postinstall {
 
 		# Not needed in the PI
 		rm -rf /usr/node/bin/{npm,npx,corepack} \
-			/usr/node/lib/node_modules/{npm,corepack} \
+			/usr/node/lib/node_modules/{npm,npx,corepack} \
 			/usr/node/include
 
 		passwd -d root

--- a/tools/debian-live
+++ b/tools/debian-live
@@ -69,7 +69,10 @@ python_ver=2.7.18
 python_distfile="https://www.python.org/ftp/python/${python_ver}/Python-${python_ver}.tgz"
 
 # Will be downloaded from nodejs.org
-node_ver=14.21.3
+node_major=14
+node_minor=21
+node_patch=3
+node_ver="${node_major}.${node_minor}.${node_patch}"
 
 # From https://willhaley.com/blog/custom-debian-live-environment/
 packages=(live-boot systemd-sysv)
@@ -468,6 +471,19 @@ function install_nodejs {
 	mkdir -p "$root/usr/node"
 	chroot "$root" tar -C /usr/node --no-same-owner --strip-components=1 -xzf -\
 	    < "$distfiles/$node_tarball"
+
+	# To the extent possible, replicate the SmartOS layout for Node. This is
+	# done in the event we need multiple versions of Node in the PI
+	chroot "$root" env NODE_MAJOR_MINOR="${node_major}.${node_minor}" bash -c '
+		cd /usr/node
+		rm -rf CHANGELOG.md LICENSE README.md share
+		mkdir -p "$NODE_MAJOR_MINOR/bin"
+
+		for i in bin/node include lib; do
+			mv "$i" "$NODE_MAJOR_MINOR/$i"
+			ln -s "/usr/node/$NODE_MAJOR_MINOR/$i" "/usr/node/$i"
+		done
+	'
 }
 
 # As much as possible, bits that are needed to support Triton will appear in
@@ -828,6 +844,11 @@ function postinstall {
 			# regardless of where we get mounted.
 			ln -s "/.var/lib/$dir" "/var/lib/$dir"
 		done
+
+		# Not needed in the PI
+		rm -rf /usr/node/bin/{npm,npx,corepack} \
+			/usr/node/lib/node_modules/{npm,corepack} \
+			/usr/node/include
 
 		passwd -d root
 

--- a/tools/debian-live
+++ b/tools/debian-live
@@ -260,7 +260,7 @@ function install_live {
 	chroot "$root" tee /etc/apt/preferences.d/90_zfs >/dev/null <<-EOF
 	# https://github.com/zfsonlinux/zfs/wiki/Debian#installation
 	Package: libnvpair1linux libuutil1linux libzfs2linux libzpool2linux spl-dkms zfs-dkms zfs-test zfsutils-linux zfsutils-linux-dev zfs-zed
-	Pin: release n=buster-backports
+	Pin: release n=bullseye-backports
 	Pin-Priority: 990
 	EOF
 
@@ -373,7 +373,7 @@ function install_usr_triton {
 
 	    # Symlink lib/node to ensure global node_modules is on the require path.
 	    # XXX - why is this node_modules not already on the nodejs require path?
-	    # This is a long explanation. Can do some reading on node docs for details:
+	    # This is a long explanation. Can do some reading on node docs for details:
 	    # https://nodejs.org/api/modules.html#modules_loading_from_the_global_folders
 	    # Note we should be doing this instead where a global module is required:
 	    # export NODE_PATH=/usr/lib/node_modules
@@ -447,7 +447,7 @@ function install_usr_triton_cn_agent {
 	    set -xeuo pipefail
 	    export LC_ALL=C
 
-	    git -C /usr/triton/defaults/agents clone -b linuxcn https://github.com/TritonDataCenter/sdc-cn-agent cn-agent
+	    git -C /usr/triton/defaults/agents clone -b LINUXCN-19 https://github.com/TritonDataCenter/sdc-cn-agent cn-agent
 	    cd /usr/triton/defaults/agents/cn-agent
 	    rm -f package-lock.json
 	    npm install --production --ignore-scripts
@@ -600,7 +600,7 @@ function install_lxd {
 	curl -L https://golang.org/dl/go${golang_ver}.linux-amd64.tar.gz |
 	    chroot "$root" tar -C /usr/local --no-same-owner -xzf -
 	LXD_RELEASE=lxd-$lxd_ver
-	curl -L https://github.com/lxc/lxd/releases/download/$LXD_RELEASE/$LXD_RELEASE.tar.gz |
+	curl -L https://github.com/canonical/lxd/releases/download/$LXD_RELEASE/$LXD_RELEASE.tar.gz |
 	    chroot "$root" tar -C /tmp --no-same-owner -xzf -
 	# shellcheck disable=2016
 	chroot "$root" env lxd_ver=$lxd_ver bash -c '
@@ -1092,15 +1092,6 @@ scratch=$top/scratch
 mkdir -p "$scratch"
 repo=$(git rev-parse --show-toplevel)
 
-motd_alt=$'
-   __        .                   .
- _|  |_      | .-. .  . .-. :--. |-
-|_    _|     ;|   ||  |(.-\' |  | |
-  |__|   `--\'  `-\' `;-| `-\' \'  \' `-\'
-                   /  ;  Platform ('"$name"' '"$release"$')
-                   `-\'   '"$docurl"'
-'
-
 motd=$'
             *--+--*--*
            /| /| /| /|
@@ -1114,8 +1105,6 @@ motd=$'
          *--*--+--*         build: '"$release"'
 
 '
-
-: "$motd_alt"
 
 commit=$(cd "$(dirname "$0")" && git rev-parse HEAD)
 product="

--- a/tools/debian-live
+++ b/tools/debian-live
@@ -42,7 +42,7 @@ docurl=https://github.com/joyent/linux-live
 golang_ver=1.15.6
 rust_version=1.52.0
 
-kernel_version=5.10.0-8
+kernel_version=5.10.0-18
 lxd_ver=4.0.6
 zfs_ver=2.0.4
 

--- a/tools/debian-live
+++ b/tools/debian-live
@@ -21,7 +21,6 @@ export PATH=/bin:/usr/bin:/usr/sbin
 
 PS4='${FUNCNAME:-debian-live}: '
 set -euo pipefail
-set -o xtrace
 
 # Unset some environment variables that can mess with chroot npm install.
 unset SUDO_COMMAND
@@ -35,19 +34,38 @@ if [[ -f ~/.cargo/env ]]; then
 	source ~/.cargo/env
 fi
 
-debver=bullseye
-name="Debian 11"
+debver=bookworm
+name="Debian 12"
 docurl=https://github.com/TritonDataCenter/linux-live
 
-# LXD >= 5 requies go >= 1.18
-golang_ver=1.18.10
-rust_version=1.52.0
+# Assuming the host and target are the same arch for now
+arch=$(dpkg --print-architecture)
+machine=$(uname -m)
 
-kernel_version=5.10.0-21
+kernel_version=6.1.0-13
+
+# Currently keeping this up with the latest version in pkgsrc bootstrap kits
+# https://us-central.manta.mnx.io/pkgsrc/public/pkg-bootstraps/index.html
+rust_version=1.73.0
 
 # $MAJOR.0.$PATCH are LTS releases for LXD
 lxd_ver=5.0.1
-zfs_ver=2.0.4
+lxd_distfile="https://github.com/canonical/lxd/releases/download/lxd-${lxd_ver}/lxd-${lxd_ver}.tar.gz"
+
+# LXD >= 5 requires go >= 1.18
+golang_ver=1.18.10
+go_distfile="https://golang.org/dl/go${golang_ver}.linux-${arch}.tar.gz"
+
+# https://github.com/openzfs/zfs/releases
+zfs_ver=2.2.0
+zfs_distfile="https://github.com/openzfs/zfs/releases/download/zfs-${zfs_ver}/zfs-${zfs_ver}.tar.gz"
+
+# Last Python 2 version released (needed for node-gyp)
+python_ver=2.7.18
+python_distfile="https://www.python.org/ftp/python/${python_ver}/Python-${python_ver}.tgz"
+
+# Will be downloaded from nodejs.org
+node_ver=14.21.3
 
 # From https://willhaley.com/blog/custom-debian-live-environment/
 packages=(live-boot systemd-sysv)
@@ -76,13 +94,13 @@ packages+=(
     lldpd
     lshw
     lsof
-    man
+    man-db
     netcat-openbsd
     ntpdate
     openssh-server
     pciutils
     psmisc
-    python # needed for bpfcc-tools
+    python3 # needed for bpfcc-tools
     rsync
     screen
     socat
@@ -91,20 +109,15 @@ packages+=(
     sysstat
     tcpdump
     vim
-    sharutils
 )
 
 # Agents build relies on uuid.
 packages+=(uuid)
 
-# NodeJS
-packages+=(nodejs)
-
 # required by lxd:
 packages+=(iptables apparmor apparmor-profiles apparmor-utils liblxc1 lxc lxcfs
-    acl autoconf dnsmasq-base git libtool rsync pkg-config make tar tcl libuv1
-    squashfs-tools xz-utils ebtables lvm2 thin-provisioning-tools btrfs-progs
-    attr
+    acl dnsmasq-base git rsync tar tcl libuv1 squashfs-tools xz-utils
+    ebtables lvm2 thin-provisioning-tools btrfs-progs attr
 )
 
 # These packages are here to aid in building the image - they are installed
@@ -112,12 +125,12 @@ packages+=(iptables apparmor apparmor-profiles apparmor-utils liblxc1 lxc lxcfs
 temp_build_packages=(gawk alien libblkid-dev uuid-dev libudev-dev libssl-dev
     zlib1g-dev libaio-dev libattr1-dev libelf-dev python3-setuptools
     python3-cffi libffi-dev build-essential gdebi dpkg-dev fakeroot debhelper
-    dkms python3-dev
+    dkms python3-dev python3-distlib autoconf pkg-config make libtool
 )
 
 # packages required to build lxd
 temp_build_packages+=(libacl1-dev libcap-dev lxc-dev libuv1-dev patchelf
-	liblz4-dev shellcheck)
+	liblz4-dev automake)
 
 # These are for the lxd test suite:
 temp_build_packages+=(libapparmor-dev libseccomp-dev libcap-dev gettext
@@ -157,6 +170,33 @@ function onfatal {
 	fi
 }
 
+
+# Download specified distfile if not already downloaded
+function fetch_distfile {
+	local url="$1"
+	local tarball
+	tarball=$(basename "$url")
+	local distfile="$distfiles/$tarball"
+
+	if [[ ! -e "$distfile" ]]; then
+		echo "Fetching distfile: $url"
+		curl -Lo "$distfile" "$url" || rm -f "$distfile"
+	fi
+}
+
+# Download and extract the specified distfile into /tmp or an optional path
+function fetch_extract_distfile {
+	local url="$1"
+	local dest="${2:-/tmp}"
+	local tarball
+	tarball=$(basename "$url")
+	local distfile="$distfiles/$tarball"
+
+	fetch_distfile "$url"
+
+	chroot "$root" tar -C "$dest" --no-same-owner -xzf - < "$distfiles/$tarball"
+}
+
 function unmount_children {
 	local dirs
 	mapfile -t dirs < <(mount | awk -v root="$root/" '
@@ -184,7 +224,6 @@ function preflight_check {
 		gdisk			# called by this script
 		git			# called by this script
 		grub-efi		# called by this script
-		grub-pc-bin		# for grub-mkstandalone
 		kpartx			# called by this script
 		zlib1g-dev		# to build src/sethostid
 		mtools			# mcopy called by this script
@@ -194,6 +233,12 @@ function preflight_check {
 		xorriso			# called by this script
 		pwgen			# called by this script
 	)
+
+	if [[ "$arch" == "amd64" ]]; then
+		packages+=(
+			grub-pc-bin	# for grub-mkstandalone
+		)
+	fi
 
 	local missing=() status
 	local missing_rust=true
@@ -206,6 +251,16 @@ function preflight_check {
 	done
 	if command -v rustc && command -v cargo ; then
 		missing_rust=false
+		rust_current_version="$(rustc -vV | grep release | awk '{print $2}')"
+		if [[ "$rust_current_version" != "$rust_version" ]]; then
+			exec 1>&2
+			echo "Expected Rust version: $rust_version"
+			echo "Found Rust version: $rust_current_version"
+			echo "To fix, run:"
+			echo "    rustup toolchain install $rust_version"
+			echo "    rustup default $rust_version"
+			exit 1
+		fi
 	fi
 	if (( ${#missing[@]} == 0 )) && [[ "$missing_rust" == "false" ]]; then
 		return 0
@@ -217,7 +272,7 @@ function preflight_check {
 			curl --proto '=https' --tlsv1.2 -sSf \
 				https://sh.rustup.rs | \
 				sh -s -- -q -y --profile minimal \
-				--default-host x86_64-unknown-linux-gnu \
+				--default-host "${machine}-unknown-linux-gnu" \
 				--default-toolchain "$rust_version"
 		fi
 		return 0
@@ -234,64 +289,48 @@ function preflight_check {
 }
 
 function create_bootstrap {
-	debootstrap --arch=amd64 --variant=minbase "$debver" "$root" \
+	cachedir="$cache/debootstrap/$debver/$arch"
+	mkdir -p "$cachedir"
+	debootstrap --verbose --arch="$arch" --variant=minbase \
+	    --cache-dir="$cachedir" "$debver" "$root" \
 	    http://ftp.us.debian.org/debian/
 }
 
 function install_live {
+
 	chroot "$root" tee /etc/apt/sources.list >/dev/null <<-EOF
-	deb http://deb.debian.org/debian/ $debver main
-	deb-src http://deb.debian.org/debian/ $debver main
+	deb http://deb.debian.org/debian/ $debver main contrib
+	deb-src http://deb.debian.org/debian/ $debver main contrib
 
-	deb http://security.debian.org/debian-security ${debver}-security main
-	deb-src http://security.debian.org/debian-security ${debver}-security main
+	deb http://security.debian.org/debian-security ${debver}-security main contrib
+	deb-src http://security.debian.org/debian-security ${debver}-security main contrib
 
-	deb http://deb.debian.org/debian/ $debver-updates main
-	deb-src http://deb.debian.org/debian/ $debver-updates main
+	deb http://deb.debian.org/debian/ ${debver}-updates main contrib
+	deb-src http://deb.debian.org/debian/ ${debver}-updates main contrib
 	EOF
 
-	#chroot "$root" tee /etc/apt/sources.list.d/$debver-backports.list \
-	#    >/dev/null <<-EOF
-	## https://github.com/zfsonlinux/zfs/wiki/Debian#installation
-	#deb http://deb.debian.org/debian $debver-backports main contrib
-	#deb-src http://deb.debian.org/debian $debver-backports main contrib
-	#EOF
-
-	chroot "$root" tee /etc/apt/preferences.d/90_zfs >/dev/null <<-EOF
-	# https://github.com/zfsonlinux/zfs/wiki/Debian#installation
-	Package: libnvpair1linux libuutil1linux libzfs2linux libzpool2linux spl-dkms zfs-dkms zfs-test zfsutils-linux zfsutils-linux-dev zfs-zed
-	Pin: release n=bullseye-backports
-	Pin-Priority: 990
-	EOF
-
-	curl -sL https://deb.nodesource.com/setup_14.x | chroot "$root" bash -
 	chroot "$root" apt update
 }
 
-# Install more recent kernel
+# Install specified kernel packages
 function install_kernel_packages {
-	# This installs the new kernel
-	chroot "$root" env DEBIAN_FRONTEND=noninteractive apt install \
-	    "${apt_args[@]}" \
-	    "linux-image-${kernel_version}-amd64" \
-	    "linux-headers-${kernel_version}-amd64"
-
-	# This removes the old kernel
-	#chroot "$root" env DEBIAN_FRONTEND=noninteractive apt-get remove \
-	    #"linux-image-4*" "linux-headers-4*" "linux-kbuild-4*"
+	chroot "$root" env DEBIAN_FRONTEND=noninteractive LC_ALL=C \
+	    apt install "${apt_args[@]}" \
+	    "linux-image-${kernel_version}-${arch}" \
+	    "linux-headers-${kernel_version}-${arch}"
 }
 
 # Install system packages.
 function install_packages {
-	chroot "$root" env DEBIAN_FRONTEND=noninteractive apt-get dist-upgrade \
-	    "${apt_args[@]}"
-	chroot "$root" env DEBIAN_FRONTEND=noninteractive apt install \
+	chroot "$root" env DEBIAN_FRONTEND=noninteractive LC_ALL=C apt-get \
+	    dist-upgrade "${apt_args[@]}"
+	chroot "$root" env DEBIAN_FRONTEND=noninteractive LC_ALL=C apt install \
 	    "${apt_args[@]}" "${packages[@]}"
 }
 
 # Install temporary packages.
 function install_temporary_packages {
-	chroot "$root" env DEBIAN_FRONTEND=noninteractive apt install \
+	chroot "$root" env DEBIAN_FRONTEND=noninteractive LC_ALL=C apt install \
 	    "${apt_args[@]}" "${temp_build_packages[@]}"
 }
 
@@ -300,42 +339,59 @@ function install_temporary_packages {
 # everything else. Once we have Linux as a platform it should be easier to run
 # things like a build farm and repo.
 function build_zfs {
+	fetch_extract_distfile "$zfs_distfile"
+	zfs_built_pkgs="$buildcache/zfs-${zfs_ver}/all-packages.tar"
+
+	# If ZFS packages have already been built for the desired version extract
+	# and install those packages instead of rebuilding
+	if [[ -f "$zfs_built_pkgs" ]]; then
+		mkdir -p "$root/tmp/zfs-${zfs_ver}"
+		cp "$zfs_built_pkgs" "$root/tmp/zfs-${zfs_ver}"
+		tar -xf "$root/tmp/zfs-${zfs_ver}/all-packages.tar" -C \
+			"$root/tmp/zfs-${zfs_ver}"
+		chroot "$root" env ZFS_VER="$zfs_ver" LC_ALL=C bash -c '
+			cd /tmp/zfs-${ZFS_VER}
+			for file in *.deb; do gdebi -q --non-interactive $file; done
+			rm -rf /tmp/zfs-${ZFS_VER}
+		'
+		return 0
+	fi
+
 	# shellcheck disable=1004 disable=2016
-	chroot "$root" env zfs_ver=$zfs_ver bash -c '
+	chroot "$root" env ZFS_VER="$zfs_ver" ARCH="$arch" bash -c '
 	    PS4="BUILD_ZFS: "
 	    set -xeuo pipefail
 
 	    export DEBIAN_FRONTEND=noninteractive
 	    export LC_ALL=C
 
-	    rm -rf zfs
-	    git clone -b zfs-$zfs_ver https://github.com/zfsonlinux/zfs.git
-	    cd zfs
+	    cd /tmp/zfs-${ZFS_VER}
 	    ./autogen.sh
 	    ./configure --with-linux=$(echo /usr/src/linux-headers-*-common) \
-	        --with-linux-obj=$(echo /usr/src/linux-headers-*-amd64) \
+	        --with-linux-obj=$(echo /usr/src/linux-headers-*-${ARCH})
 	'
 
 	clean+=(unmount_children)
 	mount -t proc proc "$root/proc"
 	# shellcheck disable=2016
-	chroot "$root" bash -c '
+	chroot "$root" env ZFS_VER="$zfs_ver" bash -c '
 	    PS4="BUILD_ZFS: "
 	    set -xeuo pipefail
 
-	    cd zfs
+	    export LC_ALL=C
+
+	    cd /tmp/zfs-${ZFS_VER}
 	    make -j1 pkg-utils deb-kmod
 	    tar cvf /all-packages.tar *.deb
 	    rm kmod-zfs-devel*.deb zfs-test*.deb
 	    tar cvf /packages.tar *.deb
 	    for file in *.deb; do gdebi -q --non-interactive $file; done
-	    cd ..
-	    rm -rf zfs
+	    rm -rf /tmp/zfs-${ZFS_VER}
 	'
 	umount "$root/proc"
 
-	mv "$root/all-packages.tar" "$root/packages.tar" "$scratch"
-
+	mkdir -p "$buildcache/zfs-${zfs_ver}"
+	mv "$root/all-packages.tar" "$zfs_built_pkgs"
 }
 
 # In the previous "apt install" we built the ZFS kernel modules and installed
@@ -343,7 +399,7 @@ function build_zfs {
 # (remove) the packages which are no longer needed.
 function remove_temporary_packages {
 	# shellcheck disable=2016
-	chroot "$root" env zfs_ver="$zfs_ver" pkgs="${temp_build_packages[*]}" \
+	chroot "$root" env pkgs="${temp_build_packages[*]}" \
 	    bash -c '
 		PS4="CLEAN_ZFS_DEV: "
 		set -xeuo pipefail
@@ -353,9 +409,61 @@ function remove_temporary_packages {
 
 		apt remove -y $pkgs "linux-headers-*"
 		apt-get autoremove --purge -y
-
-		rm -f /tmp/zfs-modules-*.deb
 	'
+}
+
+# Build Python 2 for node-gyp
+#
+# Debian 12 has removed Python 2 but we need it for older versions of node-gyp
+# We'll use it during the npm install process and remove it after. It is not
+# present in the platform image.
+# See also: https://wiki.debian.org/Python/FAQ#Python_2_support
+function build_python2 {
+
+	fetch_extract_distfile "$python_distfile"
+
+	if [[ -d "$buildcache/Python-$python_ver" ]]; then
+		cp -a "$buildcache/Python-$python_ver" "$root/tmp"
+		chroot "$root" env PYTHON_VER="$python_ver" bash -c '
+			cd "/tmp/Python-$PYTHON_VER"
+			make install
+		'
+		return 0
+	fi
+
+	chroot "$root" env PYTHON_VER=$python_ver bash -c '
+		cd "/tmp/Python-$PYTHON_VER"
+		./configure
+		make install
+	'
+	cp -a "$root/tmp/Python-$python_ver" "$buildcache"
+}
+
+function remove_python2 {
+	# There is no uninstall target in the Makefile
+	rm -rf "$root/tmp/Python-$python_ver" \
+		"$root/usr/local/bin/python2" \
+		"$root/usr/local/lib/python2.7" \
+		"$root/usr/local/bin/smtpd.py" \
+		"$root/usr/local/bin/idle" \
+		"$root/usr/local/bin/pydoc" \
+		"$root/usr/local/bin/2to3" \
+		"$root/usr/local/share/man/man1/python2"
+}
+
+function install_nodejs {
+	case "$arch" in
+		amd64) node_arch=x64;;
+		arm64) node_arch=arm64;;
+	esac
+
+	local node_tarball="node-v${node_ver}-linux-${node_arch}.tar.gz"
+
+	fetch_distfile "https://nodejs.org/download/release/v$node_ver/$node_tarball"
+
+	mkdir -p "$root/usr/node"
+	chroot "$root" tar -C /usr/node --no-same-owner --strip-components=1 -xzf -\
+	    < "$distfiles/$node_tarball"
 }
 
 # As much as possible, bits that are needed to support Triton will appear in
@@ -363,27 +471,34 @@ function remove_temporary_packages {
 function install_usr_triton {
 	chroot "$root" mkdir -p /usr/triton/bin
 	chroot "$root" mkdir -p /usr/triton/defaults/agents
+
 	chroot "$root" bash -c '
 	    PS4="INSTALL_USR_TRITON: "
 	    set -xeuo pipefail
-	    export LC_ALL=C
+	    export PATH=/usr/node/bin:$PATH
+	    export PYTHON=/usr/local/bin/python2
 
 	    # Install common node modules.
-	    npm install --production -g manta json bunyan assert-plus yamljs
+	    npm_config_user=root npm install --omit=dev -g manta json bunyan q \
+	        assert-plus yamljs
 
-	    # Symlink lib/node to ensure global node_modules is on the require path.
-	    # XXX - why is this node_modules not already on the nodejs require path?
-	    # This is a long explanation. Can do some reading on node docs for details:
-	    # https://nodejs.org/api/modules.html#modules_loading_from_the_global_folders
-	    # Note we should be doing this instead where a global module is required:
-	    # export NODE_PATH=/usr/lib/node_modules
-	    cd /usr/lib && ln -s node_modules node
+	    # Global modules can exist in the following locations:
+	    #
+	    #  /usr/node/lib/node_modules:
+	    #    Global modules are installed here as this path is relative to the
+	    #    node binary.
+	    #
+	    #   /usr/node/lib/node:
+	    #       The prebuilt binaries also look here when resolving modules
+	    #
+	    #  /usr/node/node_modules:
+	    #    Triton helper scripts expect their modules at this path so a
+	    #    symlink is made from /usr/node/lib/node_modules
+	    #
+	    #  See also: https://nodejs.org/api/modules.html#all-together
 
-	    # A lot of triton node scripts use modules from /usr/node/node_modules,
-	    # so we keep that compatability (for mkzpool, disklayout and friends).
-	    mkdir -p /usr/node/bin
-	    ln -sf /usr/lib/node /usr/node/node_modules
-	    ln -sf /usr/bin/node /usr/node/bin/node
+	    ln -s /usr/node/lib/node_modules /usr/node/node_modules
+	    ln -s /usr/node/lib/node_modules /usr/node/lib/node
 	'
 }
 
@@ -405,24 +520,24 @@ function install_usr_triton_helper_scripts {
 	    # node-getopt
 	    git -C /usr/triton clone https://github.com/TritonDataCenter/node-getopt
 	    mv /usr/triton/node-getopt/lib/getopt.js \
-		/usr/lib/node_modules/
+	        /usr/node/node_modules
 	    rm -rf /usr/triton/node-getopt
 
 	    # node-zfs
 	    # Note: required for disklayout, mkzpool.
 	    git -C /usr/triton clone -b linuxcn https://github.com/TritonDataCenter/node-zfs
 	    mv /usr/triton/node-zfs/lib/*.js \
-		/usr/lib/node_modules/
+	        /usr/node/node_modules
 	    rm -rf /usr/triton/node-zfs
 
 	    # disklayout
 	    curl -sSL https://raw.githubusercontent.com/TritonDataCenter/smartos-live/linuxcn/src/disklayout.js > \
-		/usr/triton/bin/disklayout
+	        /usr/triton/bin/disklayout
 	    chmod 700 /usr/triton/bin/disklayout
 
 	    # mkzpool
 	    curl -sSL https://raw.githubusercontent.com/TritonDataCenter/smartos-live/linuxcn/src/mkzpool.js > \
-                /usr/triton/bin/mkzpool
+	        /usr/triton/bin/mkzpool
 	    chmod 700 /usr/triton/bin/mkzpool
 	'
 }
@@ -446,11 +561,19 @@ function install_usr_triton_cn_agent {
 	    PS4="INSTALL_USR_TRITON_CN_AGENT: "
 	    set -xeuo pipefail
 	    export LC_ALL=C
+	    export PATH=/usr/node/bin:$PATH
+	    export PYTHON=/usr/local/bin/python2
 
-	    git -C /usr/triton/defaults/agents clone -b LINUXCN-19 https://github.com/TritonDataCenter/sdc-cn-agent cn-agent
+	    git -C /usr/triton/defaults/agents clone -b linuxcn \
+	        https://github.com/TritonDataCenter/sdc-cn-agent cn-agent
 	    cd /usr/triton/defaults/agents/cn-agent
 	    rm -f package-lock.json
-	    npm install --production --ignore-scripts
+
+	    # pty.js fails to install successfully but it is currently only used by
+	    # the SmartOS cn-agent backend
+	    npm uninstall pty.js
+
+	    npm install --omit=dev
 	    # Install a fake image_uuid (remove when we have a proper build).
 	    uuid -v4 > image_uuid
 	'
@@ -461,11 +584,14 @@ function install_usr_triton_imgadm {
 	chroot "$root" bash -c '
         PS4="INSTALL_USR_TRITON_IMGADM: "
         set -xeuo pipefail
-        export LC_ALL=C
+	    export LC_ALL=C
+	    export PATH=/usr/node/bin:$PATH
+	    export PYTHON=/usr/local/bin/python2
 
-        git -C /usr/triton/defaults clone -b linuxcn https://github.com/TritonDataCenter/node-imgadm imgadm
+        git -C /usr/triton/defaults clone -b linuxcn \
+            https://github.com/TritonDataCenter/node-imgadm imgadm
         cd /usr/triton/defaults/imgadm
-        npm install --production
+        npm install --omit=dev
         # Install a fake image_uuid (remove when we have a proper build).
         uuid -v4 > image_uuid
 
@@ -477,19 +603,17 @@ function install_usr_triton_imgadm {
 
 # Install config-agent and the dependencies (nice to have a build of this).
 function install_usr_triton_config_agent {
-	# git -C $scratch clone -b linuxcn https://github.com/TritonDataCenter/sdc-config-agent
-	# cd $scratch/sdc-config-agent && npm install
-	# cp -rp $scratch/sdc-config-agent $root/usr/triton/
-
 	chroot "$root" bash -c '
 	    PS4="INSTALL_USR_TRITON_CONFIG_AGENT: "
 	    set -xeuo pipefail
 	    export LC_ALL=C
+	    export PATH=/usr/node/bin:$PATH
+	    export PYTHON=/usr/local/bin/python2
 
-	    git -C /usr/triton/defaults/agents clone -b linuxcn https://github.com/TritonDataCenter/sdc-config-agent config-agent
+	    git -C /usr/triton/defaults/agents clone -b linuxcn \
+	        https://github.com/TritonDataCenter/sdc-config-agent config-agent
 	    cd /usr/triton/defaults/agents/config-agent
-	    rm -f package-lock.json
-	    npm install --production --ignore-scripts
+	    npm install --omit=dev
 	    # Install a fake image_uuid (remove when we have a proper build).
 	    uuid -v4 > image_uuid
 	'
@@ -497,19 +621,17 @@ function install_usr_triton_config_agent {
 
 # Install net-agent and the dependencies (nice to have a build of this).
 function install_usr_triton_net_agent {
-	# git -C $scratch clone -b linuxcn https://github.com/TritonDataCenter/sdc-net-agent
-	# cd $scratch/sdc-net-agent && npm install
-	# cp -rp $scratch/sdc-net-agent $root/usr/triton/
-
 	chroot "$root" bash -c '
 	    PS4="INSTALL_USR_TRITON_NET_AGENT: "
 	    set -xeuo pipefail
 	    export LC_ALL=C
+	    export PATH=/usr/node/bin:$PATH
+	    export PYTHON=/usr/local/bin/python2
 
 	    git -C /usr/triton/defaults/agents clone -b linuxcn https://github.com/TritonDataCenter/sdc-net-agent net-agent
 	    cd /usr/triton/defaults/agents/net-agent
 	    rm -f package-lock.json
-	    npm install --production --ignore-scripts
+	    npm install --omit=dev
 	    # Install a fake image_uuid (remove when we have a proper build).
 	    uuid -v4 > image_uuid
 	'
@@ -518,45 +640,51 @@ function install_usr_triton_net_agent {
 # Install vm-agent and the dependencies (nice to have a build of this).
 function install_usr_triton_vm_agent {
 	chroot "$root" bash -c '
-        PS4="INSTALL_USR_TRITON_VM_AGENT: "
-        set -xeuo pipefail
-        export LC_ALL=C
+	    PS4="INSTALL_USR_TRITON_VM_AGENT: "
+	    set -xeuo pipefail
+	    export LC_ALL=C
+	    export PATH=/usr/node/bin:$PATH
+	    export PYTHON=/usr/local/bin/python2
 
-        git -C /usr/triton/defaults/agents clone -b linuxcn https://github.com/TritonDataCenter/sdc-vm-agent vm-agent
-        cd /usr/triton/defaults/agents/vm-agent
-        npm install --production
-        # Install a fake image_uuid (remove when we have a proper build).
-        uuid -v4 > image_uuid
+	    git -C /usr/triton/defaults/agents clone -b linuxcn https://github.com/TritonDataCenter/sdc-vm-agent vm-agent
+	    cd /usr/triton/defaults/agents/vm-agent
+	    npm install --omit=dev
+	    # Install a fake image_uuid (remove when we have a proper build).
+	    uuid -v4 > image_uuid
 	'
 }
 
 # Install metadata agent and the dependencies (nice to have a build of this).
 function install_usr_triton_metadata {
 	chroot "$root" bash -c '
-        PS4="INSTALL_USR_TRITON_METADATA: "
-        set -xeuo pipefail
-        export LC_ALL=C
+	    PS4="INSTALL_USR_TRITON_METADATA: "
+	    set -xeuo pipefail
+	    export LC_ALL=C
+	    export PATH=/usr/node/bin:$PATH
+	    export PYTHON=/usr/local/bin/python2
 
-        git -C /usr/triton/defaults/agents clone -b linuxcn https://github.com/TritonDataCenter/triton-metadata metadata-agent
-        cd /usr/triton/defaults/agents/metadata-agent
-        npm install --production
-		# Install a fake image_uuid (remove when we have a proper build).
-		uuid -v4 > image_uuid
+	    git -C /usr/triton/defaults/agents clone -b linuxcn https://github.com/TritonDataCenter/triton-metadata metadata-agent
+	    cd /usr/triton/defaults/agents/metadata-agent
+	    npm install --omit=dev
+	    # Install a fake image_uuid (remove when we have a proper build).
+	    uuid -v4 > image_uuid
 	'
 }
 
 # Install vminfod and the dependencies (nice to have a build of this).
 function install_usr_triton_vminfod {
 	chroot "$root" bash -c '
-        PS4="INSTALL_USR_TRITON_VMINFOD: "
-        set -xeuo pipefail
-        export LC_ALL=C
+	    PS4="INSTALL_USR_TRITON_VMINFOD: "
+	    set -xeuo pipefail
+	    export LC_ALL=C
+	    export PATH=/usr/node/bin:$PATH
+	    export PYTHON=/usr/local/bin/python2
 
-        git -C /usr/triton/defaults/agents clone -b linuxcn https://github.com/TritonDataCenter/triton-vminfod vminfod-agent
-        cd /usr/triton/defaults/agents/vminfod-agent
-        npm install --production
-		# Install a fake image_uuid (remove when we have a proper build).
-		uuid -v4 > image_uuid
+	    git -C /usr/triton/defaults/agents clone -b linuxcn https://github.com/TritonDataCenter/triton-vminfod vminfod-agent
+	    cd /usr/triton/defaults/agents/vminfod-agent
+	    npm install --omit=dev
+	    # Install a fake image_uuid (remove when we have a proper build).
+	    uuid -v4 > image_uuid
 	'
 }
 
@@ -580,6 +708,7 @@ function install_proto {
 	    PS4="INSTALL_PROTO: "
 	    set -xeuo pipefail
 	    export LC_ALL=C
+	    export PATH=/usr/node/bin:$PATH
 
 	    services=$(find /usr/lib/systemd -type f -name triton-\*.service |
 		awk -F/ "{print \$NF}")
@@ -597,22 +726,26 @@ function install_proto {
 # Build and install LXC/LXD. Like ZFS, eventually this should be done
 # separtely and artifacts dropped into a repo so that we can install vi apt.
 function install_lxd {
-	curl -L https://golang.org/dl/go${golang_ver}.linux-amd64.tar.gz |
-	    chroot "$root" tar -C /usr/local --no-same-owner -xzf -
-	LXD_RELEASE=lxd-$lxd_ver
-	curl -L https://github.com/canonical/lxd/releases/download/$LXD_RELEASE/$LXD_RELEASE.tar.gz |
-	    chroot "$root" tar -C /tmp --no-same-owner -xzf -
+
+	fetch_extract_distfile "$lxd_distfile"
+
+	if [[ -d "$buildcache/lxd-$lxd_ver" ]]; then
+		mkdir -p "$root/usr/local/lxd"
+		cp -a "$buildcache/lxd-$lxd_ver/"* "$root/usr/local/lxd"
+		return 0
+	fi
+
+	fetch_extract_distfile "$go_distfile" /usr/local
+
 	# shellcheck disable=2016
-	chroot "$root" env lxd_ver=$lxd_ver bash -c '
+	chroot "$root" env LXD_RELEASE="/tmp/lxd-$lxd_ver" bash -c '
 	    PS4="BUILD_LXD: "
 	    set -xeuo pipefail
 
-	    export DEBIAN_FRONTEND=noninteractive
 	    export LC_ALL=C
-	    export LXD_RELEASE=/tmp/lxd-$lxd_ver
 	    export PATH=$PATH:/usr/local/go/bin
 
-	    cd $LXD_RELEASE
+	    cd "$LXD_RELEASE"
 	    export GOPATH=$(pwd)/_dist
 	    mkdir -p $GOPATH/bin
 	    export GOBIN=$GOPATH/bin
@@ -639,8 +772,10 @@ function install_lxd {
 	    patchelf --set-rpath "\$ORIGIN/../vendor/raft/.libs:\$ORIGIN/../vendor/dqlite/.libs" /usr/local/lxd/bin/lxc-to-lxd
 	    patchelf --set-rpath "\$ORIGIN/../../raft/.libs" /usr/local/lxd/vendor/dqlite/.libs/libdqlite.so.0
 
-	    rm -Rf /usr/local/go
+	    rm -Rf /usr/local/go "$LXD_RELEASE"
 	'
+
+	cp -a "$root/usr/local/lxd" "$buildcache/lxd-$lxd_ver"
 }
 
 function postinstall {
@@ -650,20 +785,32 @@ function postinstall {
 	    relase="$release" \
 	    bash -c '
 		PS4="POSTINSTALL: "
+		export LC_ALL=C
+
 		set -xeuo pipefail
 
 		echo debian-live-$release >/etc/hostname
 		echo "TRITON_RELEASE=\"$release\"" >> /etc/os-release
 
+		apt-get install -y systemd-resolved
+		sed -i -e "s/^#DNSSEC=.*/DNSSEC=false/" /etc/systemd/resolved.conf
+
+		# This service will attempt to parse the ip parameter on the kernel
+		# command line and fail, it is not needed for Triton
+		rm -f /usr/lib/systemd/system/systemd-network-generator.service
+
 		# Clean up apt/dpkg, and relocate them so that they reflect
 		# the running PI, and not just whatever was there when the
 		# pool was created.
 		apt-get autoremove --purge -y
+
 		apt-get clean
 
 		rm -rf /var/lib/apt/lists/*
 		rm -rf /var/cache/*
 		rm -f /etc/machine-id /etc/hostid
+		rm -rf /tmp/*
+		rm -f /etc/apt/apt.conf.d/02aptcache
 
 		for dir in dpkg apt; do
 			# Make this explicitly in the root
@@ -692,8 +839,6 @@ function postinstall {
 
 		rm -f /*.old
 
-		sed -i -e "s/^#DNSSEC=.*/DNSSEC=false/" /etc/systemd/resolved.conf
-
 		# The root home directory has nothing useful in it. Removing it
 		# makes it possible to have a dataset mounted on /root, thereby
 		# easily preserving SSH authorized_keys and such.
@@ -708,7 +853,7 @@ function postinstall {
 
 		depmod -a $(basename /lib/modules/*)
 		update-initramfs -u
-	    '
+	'
 }
 
 function prepare_archive_bits {
@@ -730,17 +875,17 @@ terminal_input --append serial
 terminal_output --append serial
 
 menuentry "Triton Debian Live $release without DHCP ttyS0" {
-    linux /vmlinuz boot=live console=tty0 console=ttyS1 systemd.unified_cgroup_hierarchy=0
+    linux /vmlinuz boot=live console=tty0 console=ttyS1
     initrd /initrd
 }
 
 menuentry "Triton Debian Live $release with default networking" {
-    linux /vmlinuz boot=live console=tty0 console=ttyS1 triton.dhcp-all-nics systemd.unified_cgroup_hierarchy=0
+    linux /vmlinuz boot=live console=tty0 console=ttyS1 triton.dhcp-all-nics
     initrd /initrd
 }
 
 menuentry "Triton Debian Live $release without DHCP" {
-    linux /vmlinuz boot=live systemd.unified_cgroup_hierarchy=0
+    linux /vmlinuz boot=live
     initrd /initrd
 }
 EOF
@@ -917,7 +1062,8 @@ function create_usb {
 
 	rm -f "$top/triton-debian_live-$release.usb.gz"
 	pigz -c "$disk_file" > "$top/triton-debian_live-$release.usb.gz"
-	ln -f -s "${top}/triton-debian_live-$release.usb.gz" "$top/../triton-debian_live-latest.usb.gz"
+	ln -f -s "${top}/triton-debian_live-$release.usb.gz" \
+	    "$top/../triton-debian_live-latest.usb.gz"
 
 }
 
@@ -992,6 +1138,8 @@ all_steps=(
     install_temporary_packages
     build_zfs
     install_lxd
+    build_python2
+    install_nodejs
     install_usr_triton
     install_usr_triton_helper_scripts
     install_usr_triton_ur_agent
@@ -1000,22 +1148,34 @@ all_steps=(
     install_usr_triton_net_agent
     install_usr_triton_vm_agent
     install_usr_triton_imgadm
+    remove_python2
     install_proto
     remove_temporary_packages
     postinstall
-    prepare_archive_bits
-    create_tgz
-    create_iso
-    create_usb
 )
+
+# The following steps assume Grub and/or x86
+if [[ "$arch" == "amd64" ]]; then
+	all_steps+=(
+		prepare_archive_bits
+		create_tgz
+		create_iso
+		create_usb
+	)
+fi
+
 dataset=
+aptcache=
+npmcache=
 install_missing=false
 
-while getopts d:hmr:x opt; do
+while getopts d:hmr:xa:n: opt; do
 	case $opt in
+	a)	aptcache=$OPTARG ;;
 	d)	dataset=$OPTARG ;;
 	h)	usage; exit 0 ;;
 	m)	install_missing=true ;;
+	n)	npmcache=$OPTARG ;;
 	r)	release=$OPTARG ;;
 	x)	set -x ;;
 	*)	fail_usage ;;
@@ -1080,16 +1240,24 @@ if [[ -z $dataset ]]; then
 	exit 1
 fi
 
+# Debootstrap packages, external tarballs, etc, speeds up subsequent builds
+cache=$(zfs list -Ho mountpoint "$dataset")/cache
+distfiles="$cache/distfiles"
+buildcache="$cache/build/${kernel_version}-${arch}-${machine}"
+
 dataset=$dataset/$release
 
 if ! zfs list -Ho name "$dataset" >/dev/null 2>&1; then
 	zfs create -p "$dataset"
 fi
+
 top=$(zfs list -Ho mountpoint "$dataset")
 root=$top/chroot
 image=$top/image
 scratch=$top/scratch
-mkdir -p "$scratch"
+
+mkdir -p "$scratch" "$cache" "$distfiles" "$buildcache"
+
 repo=$(git rev-parse --show-toplevel)
 
 motd=$'
@@ -1114,6 +1282,19 @@ Documentation: $docurl
 Description: $name with ZFS $zfs_ver
 Commit: $docurl/commit/$commit
 "
+
+# If using a an apt cache such as apt-cache-ng
+if [[ -n "$aptcache" ]]; then
+	mkdir -p "$root/etc/apt/apt.conf.d"
+	echo "Acquire::http::proxy \"$aptcache\";" > \
+	    "$root/etc/apt/apt.conf.d/02aptcache"
+fi
+
+# If using an NPM cache such as verdaccio
+if [[ -n "$npmcache" ]]; then
+	mkdir -p "$root/root"
+	echo "registry=$npmcache" > "$root/root/.npmrc"
+fi
 
 firststep="yes"
 

--- a/tools/debian-live
+++ b/tools/debian-live
@@ -57,7 +57,7 @@ golang_ver=1.18.10
 go_distfile="https://golang.org/dl/go${golang_ver}.linux-${arch}.tar.gz"
 
 # https://github.com/openzfs/zfs/releases
-zfs_ver=2.2.1
+zfs_ver=2.2.2
 zfs_distfile="https://github.com/openzfs/zfs/releases/download/zfs-${zfs_ver}/zfs-${zfs_ver}.tar.gz"
 
 # Last Python 2 version released (needed for node-gyp)

--- a/tools/debian-live
+++ b/tools/debian-live
@@ -35,14 +35,14 @@ if [[ -f ~/.cargo/env ]]; then
 	source ~/.cargo/env
 fi
 
-debver=buster
-name="Debian 10"
-docurl=https://github.com/TritonDataCenter/linux-live
+debver=bullseye
+name="Debian 11"
+docurl=https://github.com/joyent/linux-live
 
 golang_ver=1.15.6
 rust_version=1.52.0
 
-kernel_version=5.10.0-0.bpo.15
+kernel_version=5.10.0-8
 lxd_ver=4.0.6
 zfs_ver=2.0.4
 
@@ -99,7 +99,7 @@ packages+=(nodejs)
 # required by lxd:
 packages+=(iptables apparmor apparmor-profiles apparmor-utils liblxc1 lxc lxcfs
     acl autoconf dnsmasq-base git libtool rsync pkg-config make tar tcl libuv1
-    squashfs-tools xz-utils ebtables lvm2 thin-provisioning-tools btrfs-tools
+    squashfs-tools xz-utils ebtables lvm2 thin-provisioning-tools btrfs-progs
 )
 
 # These packages are here to aid in building the image - they are installed
@@ -237,19 +237,19 @@ function install_live {
 	deb http://deb.debian.org/debian/ $debver main
 	deb-src http://deb.debian.org/debian/ $debver main
 
-	deb http://security.debian.org/debian-security $debver/updates main
-	deb-src http://security.debian.org/debian-security $debver/updates main
+	deb http://security.debian.org/debian-security ${debver}-security main
+	deb-src http://security.debian.org/debian-security ${debver}-security main
 
 	deb http://deb.debian.org/debian/ $debver-updates main
 	deb-src http://deb.debian.org/debian/ $debver-updates main
 	EOF
 
-	chroot "$root" tee /etc/apt/sources.list.d/$debver-backports.list \
-	    >/dev/null <<-EOF
-	# https://github.com/zfsonlinux/zfs/wiki/Debian#installation
-	deb http://deb.debian.org/debian $debver-backports main contrib
-	deb-src http://deb.debian.org/debian $debver-backports main contrib
-	EOF
+	#chroot "$root" tee /etc/apt/sources.list.d/$debver-backports.list \
+	#    >/dev/null <<-EOF
+	## https://github.com/zfsonlinux/zfs/wiki/Debian#installation
+	#deb http://deb.debian.org/debian $debver-backports main contrib
+	#deb-src http://deb.debian.org/debian $debver-backports main contrib
+	#EOF
 
 	chroot "$root" tee /etc/apt/preferences.d/90_zfs >/dev/null <<-EOF
 	# https://github.com/zfsonlinux/zfs/wiki/Debian#installation
@@ -271,8 +271,8 @@ function install_kernel_packages {
 	    "linux-headers-${kernel_version}-amd64"
 
 	# This removes the old kernel
-	chroot "$root" env DEBIAN_FRONTEND=noninteractive apt-get remove \
-	    "linux-image-4*" "linux-headers-4*" "linux-kbuild-4*"
+	#chroot "$root" env DEBIAN_FRONTEND=noninteractive apt-get remove \
+	    #"linux-image-4*" "linux-headers-4*" "linux-kbuild-4*"
 }
 
 # Install system packages.
@@ -345,7 +345,7 @@ function remove_temporary_packages {
 		export DEBIAN_FRONTEND=noninteractive
 		export LC_ALL=C
 
-		apt remove -y $pkgs "kernel-headers-*"
+		apt remove -y $pkgs "linux-headers-*"
 		apt-get autoremove --purge -y
 
 		rm -f /tmp/zfs-modules-*.deb

--- a/tools/debian-live
+++ b/tools/debian-live
@@ -91,6 +91,7 @@ packages+=(
     sysstat
     tcpdump
     vim
+    sharutils
 )
 
 # Agents build relies on uuid.

--- a/tools/debian-live
+++ b/tools/debian-live
@@ -8,7 +8,7 @@
 
 #
 # Copyright 2021 Joyent, Inc.
-# Copyright 2022 MNX Cloud, Inc.
+# Copyright 2023 MNX Cloud, Inc.
 #
 
 #
@@ -37,13 +37,16 @@ fi
 
 debver=bullseye
 name="Debian 11"
-docurl=https://github.com/joyent/linux-live
+docurl=https://github.com/TritonDataCenter/linux-live
 
-golang_ver=1.15.6
+# LXD >= 5 requies go >= 1.18
+golang_ver=1.18.10
 rust_version=1.52.0
 
-kernel_version=5.10.0-18
-lxd_ver=4.0.6
+kernel_version=5.10.0-21
+
+# $MAJOR.0.$PATCH are LTS releases for LXD
+lxd_ver=5.0.1
 zfs_ver=2.0.4
 
 # From https://willhaley.com/blog/custom-debian-live-environment/
@@ -100,6 +103,7 @@ packages+=(nodejs)
 packages+=(iptables apparmor apparmor-profiles apparmor-utils liblxc1 lxc lxcfs
     acl autoconf dnsmasq-base git libtool rsync pkg-config make tar tcl libuv1
     squashfs-tools xz-utils ebtables lvm2 thin-provisioning-tools btrfs-progs
+    attr
 )
 
 # These packages are here to aid in building the image - they are installed
@@ -111,7 +115,8 @@ temp_build_packages=(gawk alien libblkid-dev uuid-dev libudev-dev libssl-dev
 )
 
 # packages required to build lxd
-temp_build_packages+=(libacl1-dev libcap-dev lxc-dev libuv1-dev patchelf)
+temp_build_packages+=(libacl1-dev libcap-dev lxc-dev libuv1-dev patchelf
+	liblz4-dev shellcheck)
 
 # These are for the lxd test suite:
 temp_build_packages+=(libapparmor-dev libseccomp-dev libcap-dev gettext
@@ -469,7 +474,6 @@ function install_usr_triton_imgadm {
 	'
 }
 
-
 # Install config-agent and the dependencies (nice to have a build of this).
 function install_usr_triton_config_agent {
 	# git -C $scratch clone -b linuxcn https://github.com/TritonDataCenter/sdc-config-agent
@@ -489,7 +493,6 @@ function install_usr_triton_config_agent {
 	    uuid -v4 > image_uuid
 	'
 }
-
 
 # Install net-agent and the dependencies (nice to have a build of this).
 function install_usr_triton_net_agent {
@@ -511,7 +514,6 @@ function install_usr_triton_net_agent {
 	'
 }
 
-
 # Install vm-agent and the dependencies (nice to have a build of this).
 function install_usr_triton_vm_agent {
 	chroot "$root" bash -c '
@@ -526,7 +528,6 @@ function install_usr_triton_vm_agent {
         uuid -v4 > image_uuid
 	'
 }
-
 
 # Install metadata agent and the dependencies (nice to have a build of this).
 function install_usr_triton_metadata {
@@ -543,7 +544,6 @@ function install_usr_triton_metadata {
 	'
 }
 
-
 # Install vminfod and the dependencies (nice to have a build of this).
 function install_usr_triton_vminfod {
 	chroot "$root" bash -c '
@@ -558,7 +558,6 @@ function install_usr_triton_vminfod {
 		uuid -v4 > image_uuid
 	'
 }
-
 
 function install_proto {
 	(cd "$repo/src" && make install)
@@ -592,7 +591,6 @@ function install_proto {
 		ln -s /usr/triton/bin/sysinfo /usr/bin/sysinfo
 	    fi
 	'
-
 }
 
 # Build and install LXC/LXD. Like ZFS, eventually this should be done
@@ -619,16 +617,26 @@ function install_lxd {
 	    export GOBIN=$GOPATH/bin
 
 	    make deps
-	    export CGO_CFLAGS="-I${GOPATH}/deps/sqlite/ -I${GOPATH}/deps/libco/ -I${GOPATH}/deps/raft/include/ -I${GOPATH}/deps/dqlite/include/"
-	    export CGO_LDFLAGS="-L${GOPATH}/deps/sqlite/.libs/ -L${GOPATH}/deps/libco/ -L${GOPATH}/deps/raft/.libs -L${GOPATH}/deps/dqlite/.libs/"
-	    export LD_LIBRARY_PATH="${GOPATH}/deps/sqlite/.libs/:${GOPATH}/deps/libco/:${GOPATH}/deps/raft/.libs/:${GOPATH}/deps/dqlite/.libs/"
-	    export CGO_LDFLAGS_ALLOW="-Wl,-wrap,pthread_create"
+
+	    export CGO_CFLAGS="-I${LXD_RELEASE}/vendor/raft/include/ -I${LXD_RELEASE}/vendor/dqlite/include/"
+	    export CGO_LDFLAGS="-L${LXD_RELEASE}/vendor/raft/.libs/ -L${LXD_RELEASE}/vendor/dqlite/.libs/"
+	    export LD_LIBRARY_PATH="${LXD_RELEASE}/vendor/raft/.libs/:${LXD_RELEASE}/vendor/dqlite/.libs/"
+	    export CGO_LDFLAGS_ALLOW="(-Wl,-wrap,pthread_create)|(-Wl,-z,now)"
 
 	    make
+
 	    mv $(pwd)/_dist /usr/local/lxd
 
+	    mkdir -p /usr/local/lxd/vendor/raft/.libs
+	    mv vendor/raft/.libs/*.so* /usr/local/lxd/vendor/raft/.libs
+
+	    mkdir -p /usr/local/lxd/vendor/dqlite/.libs
+	    mv vendor/dqlite/.libs/*.so* /usr/local/lxd/vendor/dqlite/.libs
+
 	    # Add dynamic libraries to the lxd binary rpath.
-	    patchelf --set-rpath "\$ORIGIN/../deps/raft/.libs:\$ORIGIN/../deps/dqlite/.libs" /usr/local/lxd/bin/lxd
+	    patchelf --set-rpath "\$ORIGIN/../vendor/raft/.libs:\$ORIGIN/../vendor/dqlite/.libs" /usr/local/lxd/bin/lxd
+	    patchelf --set-rpath "\$ORIGIN/../vendor/raft/.libs:\$ORIGIN/../vendor/dqlite/.libs" /usr/local/lxd/bin/lxc-to-lxd
+	    patchelf --set-rpath "\$ORIGIN/../../raft/.libs" /usr/local/lxd/vendor/dqlite/.libs/libdqlite.so.0
 
 	    rm -Rf /usr/local/go
 	'
@@ -709,7 +717,7 @@ function prepare_archive_bits {
 	cp "$root/initrd.img" "$image/initrd"
 
 	cat <<EOF >"$scratch/grub.cfg"
-search --set=root --file /JOYENT_DEBIAN_LIVE
+search --set=root --file /TRITON_DEBIAN_LIVE
 
 insmod all_video
 
@@ -721,21 +729,21 @@ terminal_input --append serial
 terminal_output --append serial
 
 menuentry "Triton Debian Live $release without DHCP ttyS0" {
-    linux /vmlinuz boot=live console=tty0 console=ttyS1
+    linux /vmlinuz boot=live console=tty0 console=ttyS1 systemd.unified_cgroup_hierarchy=0
     initrd /initrd
 }
 
 menuentry "Triton Debian Live $release with default networking" {
-    linux /vmlinuz boot=live console=tty0 console=ttyS1 triton.dhcp-all-nics
+    linux /vmlinuz boot=live console=tty0 console=ttyS1 triton.dhcp-all-nics systemd.unified_cgroup_hierarchy=0
     initrd /initrd
 }
 
 menuentry "Triton Debian Live $release without DHCP" {
-    linux /vmlinuz boot=live
+    linux /vmlinuz boot=live systemd.unified_cgroup_hierarchy=0
     initrd /initrd
 }
 EOF
-	echo "$release" > "$image/JOYENT_DEBIAN_LIVE"
+	echo "$release" > "$image/TRITON_DEBIAN_LIVE"
 }
 
 function create_tgz {
@@ -800,17 +808,17 @@ function create_iso {
 	    "$scratch/bios.img"
 
 	xorriso -as mkisofs -iso-level 3 -full-iso9660-filenames \
-	    -volid "JOYENT_DEBIAN_LIVE" -eltorito-boot boot/grub/bios.img \
+	    -volid "TRITON_DEBIAN_LIVE" -eltorito-boot boot/grub/bios.img \
 	    -no-emul-boot -boot-load-size 4 -boot-info-table \
 	    --eltorito-catalog boot/grub/boot.cat --grub2-boot-info \
 	    --grub2-mbr /usr/lib/grub/i386-pc/boot_hybrid.img \
 	    -eltorito-alt-boot -e EFI/efiboot.img -no-emul-boot \
 	    -append_partition 2 0xef "$scratch/efiboot.img" \
-	    -output "$top/joyent-debian_live-$release.iso" \
+	    -output "$top/triton-debian_live-$release.iso" \
 	    -graft-points "$image" /boot/grub/bios.img="$scratch/bios.img" \
 	    /EFI/efiboot.img="$scratch/efiboot.img"
 
-	    ln -f -s "${top}/joyent-debian_live-$release.iso" "$top/../joyent-debian_live-latest.iso"
+	    ln -f -s "${top}/triton-debian_live-$release.iso" "$top/../triton-debian_live-latest.iso"
 }
 
 # Creates a USB disk that should be bootable with BIOS or UEFI. The partition
@@ -832,7 +840,7 @@ function create_usb {
 	local image_mnt=$scratch/mnt/image
 	local total_sec=$(( image_start + image_sec ))
 	local disk_mb=$(( total_sec / 2 / 1024 + 1 ))
-	local disk_file=$scratch/joyent-debian_live-$release.usb
+	local disk_file=$scratch/triton-debian_live-$release.usb
 
 	truncate -s "$disk_mb"M "$disk_file"
 
@@ -906,9 +914,9 @@ function create_usb {
 	umount "$image_mnt"
 	umount "$esp_mnt"
 
-	rm -f "$top/joyent-debian_live-$release.usb.gz"
-	pigz -c "$disk_file" > "$top/joyent-debian_live-$release.usb.gz"
-	ln -f -s "${top}/joyent-debian_live-$release.usb.gz" "$top/../joyent-debian_live-latest.usb.gz"
+	rm -f "$top/triton-debian_live-$release.usb.gz"
+	pigz -c "$disk_file" > "$top/triton-debian_live-$release.usb.gz"
+	ln -f -s "${top}/triton-debian_live-$release.usb.gz" "$top/../triton-debian_live-latest.usb.gz"
 
 }
 
@@ -1094,7 +1102,7 @@ motd_alt=$'
 
 motd=$'
             *--+--*--*
-           /| /| /| /|    J O Y E N T
+           /| /| /| /|
           / |/ |/ |/ |    #####  ####   #  #####  ###   #   # TM
          +--*--+--*--*      #    #   #  #    #   #   #  ##  #
          | /| /| /| /|      #    ####   #    #   #   #  # # #

--- a/tools/debian-live
+++ b/tools/debian-live
@@ -17,6 +17,10 @@
 # making this problem easily approachable.
 #
 
+ROOT=$(cd "$(dirname "$0")"/../; pwd)
+
+. "${ROOT}/proto/usr/triton/lib/trace_logger.sh"
+
 export PATH=/bin:/usr/bin:/usr/sbin
 
 PS4='${FUNCNAME:-debian-live}: '
@@ -792,6 +796,9 @@ function postinstall {
 		echo debian-live-$release >/etc/hostname
 		echo "TRITON_RELEASE=\"$release\"" >> /etc/os-release
 
+		# systemd-resolved is installed here as doing it in the install_packages
+		# step along with other $packages causes DNS resolution to fail in the
+		# chroot
 		apt-get install -y systemd-resolved
 		sed -i -e "s/^#DNSSEC=.*/DNSSEC=false/" /etc/systemd/resolved.conf
 


### PR DESCRIPTION
Distribution tarballs (Node, ZFS, and Python) and build artifacts (ZFS, Python) are now being cached which speeds up build times.

Debian packages and npm modules can also optionally be retrieved from a cache using either of the following options which makes the build resilient to network or upstream service disruption:

`-a URL` Tested using [apt-cache-ng](https://wiki.debian.org/AptCacherNg)
`-n URL` Tested using [verdaccio](https://verdaccio.org/)

# Testing requirements

The following requirements will be available in the next Triton release ("E.D.I.T.H.") until then one needs to meet the following:

- If booting via UEFI, the CN must be booted with the updated iPXE bits from [LINUXCN-21](https://smartos.org/bugview/LINUXCN-21) a USB key with [this headnode build](https://us-central.manta.mnx.io/Joyent_Dev/public/builds/headnode/master-PR-22-20231013T001246Z-g500fc4a/headnode/usb-master-PR-22-20231013T001246Z-g500fc4a.tgz) will work.
- The headnode (specifically the joysetup.sh) needs the changes from [LINUXCN-25](https://smartos.org/bugview/LINUXCN-25)
- A Linux CN platform image with the above changes such as one of these: [platform](https://us-central.manta.mnx.io/tpaul/public/pr/LINUXCN-18/platform-20240103T202141Z.tgz), [usb](https://us-central.manta.mnx.io/tpaul/public/pr/LINUXCN-18/triton-debian_live-20240103T202141Z.usb.gz), [iso](https://us-central.manta.mnx.io/tpaul/public/pr/LINUXCN-18/triton-debian_live-20240103T202141Z.iso)

See [LINUXCN-18](https://mnx.atlassian.net/browse/LINUXCN-18?focusedCommentId=122993) for more testing notes.

[LINUXCN-21]: https://mnx.atlassian.net/browse/LINUXCN-21?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[LINUXCN-25]: https://mnx.atlassian.net/browse/LINUXCN-25?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ